### PR TITLE
Use ring buffer in DisplayTask

### DIFF
--- a/src/main/java/me/mattstudios/holovid/display/BufferedDisplayTask.java
+++ b/src/main/java/me/mattstudios/holovid/display/BufferedDisplayTask.java
@@ -23,17 +23,11 @@ public final class BufferedDisplayTask extends DisplayTask {
     }
 
     @Override
-    public void run() {
+    protected void prerun() throws InterruptedException {
         // Give the processing a headstart
         if (startDelay > 0) {
-            try {
-                Thread.sleep(startDelay);
-            } catch (final InterruptedException e) {
-                e.printStackTrace();
-            }
+            Thread.sleep(startDelay);
         }
-
-        super.run();
     }
 
     @Override
@@ -52,12 +46,6 @@ public final class BufferedDisplayTask extends DisplayTask {
             frameText[i] = dataToComponent(frame[i]);
         }
         return frameText;
-    }
-
-    @Override
-    public void stop() {
-        super.stop();
-        frames.clear();
     }
 
     public ArrayBlockingQueue<int[][]> getFrameQueue() {

--- a/src/main/java/me/mattstudios/holovid/display/BufferedDisplayTask.java
+++ b/src/main/java/me/mattstudios/holovid/display/BufferedDisplayTask.java
@@ -1,19 +1,13 @@
 package me.mattstudios.holovid.display;
 
 import me.mattstudios.holovid.Holovid;
-import net.minecraft.server.v1_16_R1.ChatBaseComponent;
-import net.minecraft.server.v1_16_R1.ChatComponentText;
-import net.minecraft.server.v1_16_R1.ChatHexColor;
-import net.minecraft.server.v1_16_R1.ChatModifier;
-import net.minecraft.server.v1_16_R1.IChatBaseComponent;
+import net.minecraft.server.v1_16_R1.*;
 
-import java.util.Queue;
 import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.LinkedBlockingQueue;
 
 public final class BufferedDisplayTask extends DisplayTask {
 
-    private final LinkedBlockingQueue<int[][]> frames;
+    private final ArrayBlockingQueue<int[][]> frames;
     private final int bufferCapacity;
     private final long startDelay;
     private final int max;
@@ -25,7 +19,7 @@ public final class BufferedDisplayTask extends DisplayTask {
 
         // Buffer up to 30 seconds beforehand
         this.bufferCapacity = 30 * fps;
-        this.frames = new LinkedBlockingQueue<>(bufferCapacity);
+        this.frames = new ArrayBlockingQueue<>(bufferCapacity);
     }
 
     @Override
@@ -48,15 +42,9 @@ public final class BufferedDisplayTask extends DisplayTask {
     }
 
     @Override
-    protected IChatBaseComponent[] getCurrentFrame() {
+    protected IChatBaseComponent[] getCurrentFrame() throws InterruptedException {
         // Block until the frame is processed
-        int[][] frame;
-        try {
-            frame = frames.take();
-        } catch (InterruptedException e){
-            e.printStackTrace(); //Something went wrong this should never be hit
-            return null;
-        }
+        int[][] frame = frames.take();
 
         // Convert to json component
         final IChatBaseComponent[] frameText = new IChatBaseComponent[frame.length];
@@ -72,7 +60,7 @@ public final class BufferedDisplayTask extends DisplayTask {
         frames.clear();
     }
 
-    public LinkedBlockingQueue<int[][]> getFrameQueue() {
+    public ArrayBlockingQueue<int[][]> getFrameQueue() {
         return frames;
     }
 

--- a/src/main/java/me/mattstudios/holovid/display/BufferedDisplayTask.java
+++ b/src/main/java/me/mattstudios/holovid/display/BufferedDisplayTask.java
@@ -1,7 +1,11 @@
 package me.mattstudios.holovid.display;
 
 import me.mattstudios.holovid.Holovid;
-import net.minecraft.server.v1_16_R1.*;
+import net.minecraft.server.v1_16_R1.ChatBaseComponent;
+import net.minecraft.server.v1_16_R1.ChatComponentText;
+import net.minecraft.server.v1_16_R1.ChatHexColor;
+import net.minecraft.server.v1_16_R1.ChatModifier;
+import net.minecraft.server.v1_16_R1.IChatBaseComponent;
 
 import java.util.concurrent.ArrayBlockingQueue;
 

--- a/src/main/java/me/mattstudios/holovid/display/DisplayTask.java
+++ b/src/main/java/me/mattstudios/holovid/display/DisplayTask.java
@@ -13,7 +13,7 @@ public abstract class DisplayTask implements Runnable {
     private final Holovid plugin;
     private final long frameDelay;
     private final boolean repeat;
-    private long lastDisplayed;
+    private long lastDisplayed = 0L;
     protected int frameCounter;
 
     private Lock runningInfoLock = new ReentrantLock();

--- a/src/main/java/me/mattstudios/holovid/display/DisplayTask.java
+++ b/src/main/java/me/mattstudios/holovid/display/DisplayTask.java
@@ -5,6 +5,8 @@ import me.mattstudios.holovid.hologram.HologramLine;
 import net.minecraft.server.v1_16_R1.IChatBaseComponent;
 
 import java.util.List;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 public abstract class DisplayTask implements Runnable {
 
@@ -14,7 +16,9 @@ public abstract class DisplayTask implements Runnable {
     private long lastDisplayed;
     protected int frameCounter;
 
-    private Thread runningThread;
+    private Lock runningInfoLock = new ReentrantLock();
+    private Thread runningThread = null;
+    private boolean deadBeforeStarted = false;
 
     protected DisplayTask(final Holovid plugin, final boolean repeat, final int fps) {
         this.plugin = plugin;
@@ -24,7 +28,21 @@ public abstract class DisplayTask implements Runnable {
 
     @Override
     public void run() {
+        this.runningInfoLock.lock();
+        if (deadBeforeStarted)
+            return;
+
         this.runningThread = Thread.currentThread();
+        this.runningInfoLock.unlock();
+
+
+        try {
+            prerun();
+        } catch (InterruptedException e) {
+            // We were stopped during the prerun, so just exit now.
+            return;
+        }
+
         do {
             try {
                 runCycle();
@@ -33,6 +51,8 @@ public abstract class DisplayTask implements Runnable {
             }
         } while (!Thread.interrupted());
     }
+
+    protected void prerun() throws InterruptedException {}
 
     private void runCycle() throws InterruptedException {
         // Load the frame in
@@ -73,6 +93,13 @@ public abstract class DisplayTask implements Runnable {
     protected abstract IChatBaseComponent[] getCurrentFrame() throws InterruptedException;
 
     public void stop() {
-        this.runningThread.interrupt();
+        // This should only actually block for any period of time when the task is initially starting
+        this.runningInfoLock.lock();
+        // Set this regardless of whether runningThread has been set yet - it doesn't matter.
+        deadBeforeStarted = true;
+        if (this.runningThread != null) {
+            this.runningThread.interrupt();
+        }
+        this.runningInfoLock.unlock();
     }
 }

--- a/src/main/java/me/mattstudios/holovid/display/FileDisplayTask.java
+++ b/src/main/java/me/mattstudios/holovid/display/FileDisplayTask.java
@@ -35,12 +35,6 @@ public final class FileDisplayTask extends DisplayTask {
         return getFrame(file);
     }
 
-    @Override
-    public void stop() {
-        super.stop();
-        files.clear();
-    }
-
     private IChatBaseComponent[] getFrame(final File file) {
         try {
             final BufferedImage image = ImageIO.read(file);


### PR DESCRIPTION
Also modifies DisplayTask to use Java thread interrupts for control
throw, which integrates with held locks and sleeps to properly die
immediately.

Partially reverts #7 