### PR TITLE
Properly do the task frame delay

### DIFF
--- a/src/main/java/me/mattstudios/holovid/display/BufferedDisplayTask.java
+++ b/src/main/java/me/mattstudios/holovid/display/BufferedDisplayTask.java
@@ -42,7 +42,7 @@ public final class BufferedDisplayTask extends DisplayTask {
     @Override
     protected IChatBaseComponent[] getCurrentFrame() throws InterruptedException {
         // Block until the frame is processed
-        int[][] frame = frames.take();
+        final int[][] frame = frames.take();
 
         // Convert to json component
         final IChatBaseComponent[] frameText = new IChatBaseComponent[frame.length];

--- a/src/main/java/me/mattstudios/holovid/display/BufferedDisplayTask.java
+++ b/src/main/java/me/mattstudios/holovid/display/BufferedDisplayTask.java
@@ -3,8 +3,6 @@ package me.mattstudios.holovid.display;
 import me.mattstudios.holovid.Holovid;
 import net.minecraft.server.v1_16_R1.ChatBaseComponent;
 import net.minecraft.server.v1_16_R1.ChatComponentText;
-import net.minecraft.server.v1_16_R1.ChatHexColor;
-import net.minecraft.server.v1_16_R1.ChatModifier;
 import net.minecraft.server.v1_16_R1.IChatBaseComponent;
 
 import java.util.concurrent.ArrayBlockingQueue;
@@ -62,10 +60,12 @@ public final class BufferedDisplayTask extends DisplayTask {
 
     private IChatBaseComponent dataToComponent(final int[] row) {
         final ChatBaseComponent component = new ChatComponentText("");
-        for (final int rgb : row) {
-            final ChatComponentText text = new ChatComponentText("█");
-            text.setChatModifier(ChatModifier.b.setColor(ChatHexColor.a(rgb & 0x00FFFFFF)));
-            component.addSibling(text);
+        ChatComponentText lastComponent = null;
+        int lastRgb = 0xFFFFFF;
+        for (int rgb : row) {
+            rgb &= 0x00FFFFFF;
+            lastComponent = appendComponent(component, rgb, lastRgb, lastComponent);
+            lastRgb = rgb;
         }
         return component;
     }

--- a/src/main/java/me/mattstudios/holovid/display/DisplayTask.java
+++ b/src/main/java/me/mattstudios/holovid/display/DisplayTask.java
@@ -2,6 +2,10 @@ package me.mattstudios.holovid.display;
 
 import me.mattstudios.holovid.Holovid;
 import me.mattstudios.holovid.hologram.HologramLine;
+import net.minecraft.server.v1_16_R1.ChatBaseComponent;
+import net.minecraft.server.v1_16_R1.ChatComponentText;
+import net.minecraft.server.v1_16_R1.ChatHexColor;
+import net.minecraft.server.v1_16_R1.ChatModifier;
 import net.minecraft.server.v1_16_R1.IChatBaseComponent;
 
 import java.util.List;
@@ -107,5 +111,23 @@ public abstract class DisplayTask implements Runnable {
             this.runningThread.interrupt();
         }
         this.runningInfoLock.unlock();
+    }
+
+    protected ChatComponentText appendComponent(final ChatBaseComponent parent, final int rgb, final int lastRgb, final ChatComponentText lastComponent) {
+        final ChatComponentText component;
+        if (lastComponent != null && rgb == lastRgb) {
+            // Add the character to the last component (with the same color)
+            component = new ChatComponentText(lastComponent.g() + "█");
+            // Replace old component
+            component.setChatModifier(lastComponent.getChatModifier());
+
+            parent.getSiblings().set(parent.getSiblings().size() - 1, component);
+        } else {
+            // Add a new component
+            component = new ChatComponentText("█");
+            component.setChatModifier(ChatModifier.b.setColor(ChatHexColor.a(rgb)));
+            parent.addSibling(component);
+        }
+        return component;
     }
 }

--- a/src/main/java/me/mattstudios/holovid/display/DisplayTask.java
+++ b/src/main/java/me/mattstudios/holovid/display/DisplayTask.java
@@ -13,12 +13,12 @@ public abstract class DisplayTask implements Runnable {
     private final Holovid plugin;
     private final long frameDelay;
     private final boolean repeat;
-    private long lastDisplayed = 0L;
+    private long lastDisplayed;
     protected int frameCounter;
 
-    private Lock runningInfoLock = new ReentrantLock();
-    private Thread runningThread = null;
-    private boolean deadBeforeStarted = false;
+    private final Lock runningInfoLock = new ReentrantLock();
+    private Thread runningThread;
+    private boolean deadBeforeStarted;
 
     protected DisplayTask(final Holovid plugin, final boolean repeat, final int fps) {
         this.plugin = plugin;
@@ -29,16 +29,16 @@ public abstract class DisplayTask implements Runnable {
     @Override
     public void run() {
         this.runningInfoLock.lock();
-        if (deadBeforeStarted)
+        if (deadBeforeStarted) {
             return;
+        }
 
         this.runningThread = Thread.currentThread();
         this.runningInfoLock.unlock();
 
-
         try {
             prerun();
-        } catch (InterruptedException e) {
+        } catch (final InterruptedException e) {
             // We were stopped during the prerun, so just exit now.
             return;
         }
@@ -46,13 +46,14 @@ public abstract class DisplayTask implements Runnable {
         do {
             try {
                 runCycle();
-            } catch (InterruptedException e) {
+            } catch (final InterruptedException e) {
                 return;
             }
         } while (!Thread.interrupted());
     }
 
-    protected void prerun() throws InterruptedException {}
+    protected void prerun() throws InterruptedException {
+    }
 
     private void runCycle() throws InterruptedException {
         // Load the frame in

--- a/src/main/java/me/mattstudios/holovid/display/FileDisplayTask.java
+++ b/src/main/java/me/mattstudios/holovid/display/FileDisplayTask.java
@@ -46,10 +46,12 @@ public final class FileDisplayTask extends DisplayTask {
 
             for (int y = 0; y < height; y++) {
                 final ChatBaseComponent component = new ChatComponentText("");
+                ChatComponentText lastComponent = null;
+                int lastRgb = 0xFFFFFF;
                 for (int x = 0; x < width; x++) {
-                    final ChatComponentText text = new ChatComponentText("█");
-                    text.setChatModifier(ChatModifier.b.setColor(ChatHexColor.a(rgbArray[y * width + x] & 0x00FFFFFF)));
-                    component.addSibling(text);
+                    final int rgb = rgbArray[y * width + x] & 0x00FFFFFF;
+                    lastComponent = appendComponent(component, rgb, lastRgb, lastComponent);
+                    lastRgb = rgb;
                 }
                 frame[image.getHeight() - y - 1] = component;
             }


### PR DESCRIPTION
The single frames are now actually sent at the very millisecond they should be sent, keeping the video perfectly in sync (unless the client itself struggles to display it): https://youtu.be/FljvARtuskc

Also edited the downloader to properly interrupt, similar to the display task (probably not perfect, but better than before and works)