### PR TITLE
Prepare for audiodownloading, some fixes to cancelling and display

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,9 +37,9 @@ allprojects {
 
         implementation "com.github.sealedtx:java-youtube-downloader:2.2.0"
 
-        implementation "org.jcodec:jcodec:0.2.3"
-        implementation "org.jcodec:jcodec-android:0.2.3"
-        implementation "org.jcodec:jcodec-javase:0.2.3"
+        implementation "org.jcodec:jcodec:0.2.5"
+        implementation "org.jcodec:jcodec-android:0.2.5"
+        implementation "org.jcodec:jcodec-javase:0.2.5"
         implementation "net.coobird:thumbnailator:0.4.11"
 
     }

--- a/src/main/java/me/mattstudios/holovid/Holovid.java
+++ b/src/main/java/me/mattstudios/holovid/Holovid.java
@@ -44,14 +44,16 @@ public final class Holovid extends JavaPlugin {
     private Hologram hologram;
     private DisplayTask task;
 
-    private int displayHeight = 72;
-    private int displayWidth = 128;
+    private int displayHeight;
+    private int displayWidth;
+    private boolean shouldRequestAudio;
 
     @Override
     public void onEnable() {
         saveDefaultConfig();
         displayHeight = getConfig().getInt("display-height", 144);
         displayWidth = getConfig().getInt("display-width", 256);
+        shouldRequestAudio = getConfig().getBoolean("request-audio");
 
         // Loads the tasks util
         Task.init(this);
@@ -242,5 +244,9 @@ public final class Holovid extends JavaPlugin {
 
     public int getDisplayWidth() {
         return displayWidth;
+    }
+
+    public boolean shouldRequestAudio() {
+        return shouldRequestAudio;
     }
 }

--- a/src/main/java/me/mattstudios/holovid/Holovid.java
+++ b/src/main/java/me/mattstudios/holovid/Holovid.java
@@ -7,16 +7,19 @@ import me.mattstudios.holovid.command.SpawnScreenCommand;
 import me.mattstudios.holovid.command.StopCommand;
 import me.mattstudios.holovid.display.BufferedDisplayTask;
 import me.mattstudios.holovid.display.DisplayTask;
+import me.mattstudios.holovid.download.AudioProcessor;
 import me.mattstudios.holovid.download.VideoDownloader;
 import me.mattstudios.holovid.download.VideoProcessor;
 import me.mattstudios.holovid.download.YouTubeDownloader;
 import me.mattstudios.holovid.hologram.Hologram;
 import me.mattstudios.holovid.listener.HologramListener;
+import me.mattstudios.holovid.listener.ResourcePackStatusListener;
 import me.mattstudios.holovid.utils.Task;
 import me.mattstudios.mf.base.CommandManager;
 import me.mattstudios.mf.base.components.TypeResult;
 import org.apache.commons.validator.routines.UrlValidator;
 import org.bukkit.Location;
+import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.Nullable;
 
@@ -29,9 +32,11 @@ import java.util.stream.Collectors;
 
 public final class Holovid extends JavaPlugin {
 
+    public static final int MAX_SECONDS_FOR_AUDIO = 60 * 60; // Don't even try changing this, the external server checks for it as well
     public static final int PRE_RENDER_SECONDS = 20;
     private CommandManager commandManager;
     private VideoProcessor videoProcessor;
+    private AudioProcessor audioProcessor;
     private VideoDownloader videoDownloader;
     private Hologram hologram;
     private DisplayTask task;
@@ -50,9 +55,12 @@ public final class Holovid extends JavaPlugin {
 
         commandManager = new CommandManager(this);
         videoProcessor = new VideoProcessor(this);
+        audioProcessor = new AudioProcessor(this);
         videoDownloader = new YouTubeDownloader(this);
 
-        getServer().getPluginManager().registerEvents(new HologramListener(this), this);
+        final PluginManager pluginManager = getServer().getPluginManager();
+        pluginManager.registerEvents(new HologramListener(this), this);
+        pluginManager.registerEvents(new ResourcePackStatusListener(this), this);
         registerCommands();
     }
 
@@ -164,6 +172,10 @@ public final class Holovid extends JavaPlugin {
 
     public VideoProcessor getVideoProcessor() {
         return videoProcessor;
+    }
+
+    public AudioProcessor getAudioProcessor() {
+        return audioProcessor;
     }
 
     public VideoDownloader getVideoDownloader() {

--- a/src/main/java/me/mattstudios/holovid/Holovid.java
+++ b/src/main/java/me/mattstudios/holovid/Holovid.java
@@ -19,6 +19,7 @@ import me.mattstudios.mf.base.CommandManager;
 import me.mattstudios.mf.base.components.TypeResult;
 import org.apache.commons.validator.routines.UrlValidator;
 import org.bukkit.Location;
+import org.bukkit.SoundCategory;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.PluginManager;
@@ -189,7 +190,7 @@ public final class Holovid extends JavaPlugin {
         final boolean running = task != null;
         if (running) {
             for (final Player player : getServer().getOnlinePlayers()) {
-                player.stopSound("holovid.video");
+                player.stopSound("holovid.video", SoundCategory.RECORDS);
             }
             task.stop();
             task = null;

--- a/src/main/java/me/mattstudios/holovid/Holovid.java
+++ b/src/main/java/me/mattstudios/holovid/Holovid.java
@@ -164,6 +164,9 @@ public final class Holovid extends JavaPlugin {
     public boolean stopDisplayTask() {
         final boolean running = task != null;
         if (running) {
+            for (final Player player : getServer().getOnlinePlayers()) {
+                player.stopSound("holovid.video");
+            }
             task.stop();
             task = null;
         }

--- a/src/main/java/me/mattstudios/holovid/Holovid.java
+++ b/src/main/java/me/mattstudios/holovid/Holovid.java
@@ -124,7 +124,7 @@ public final class Holovid extends JavaPlugin {
         final int frames = dataConfig.getInt("frames");
         final int height = dataConfig.getInt("height");
         final int width = dataConfig.getInt("width");
-        final boolean requestSoundData = fps * frames < Holovid.MAX_SECONDS_FOR_AUDIO;
+        final boolean requestSoundData = frames / fps < Holovid.MAX_SECONDS_FOR_AUDIO;
         Task.async(() -> videoProcessor.play(player, videoFile, url, requestSoundData, height, width, frames, fps, interlace));
     }
 

--- a/src/main/java/me/mattstudios/holovid/command/DownloadCommand.java
+++ b/src/main/java/me/mattstudios/holovid/command/DownloadCommand.java
@@ -27,9 +27,13 @@ public final class DownloadCommand extends CommandBase {
             player.sendMessage("Use /holovid spawnscreen to spawn the armor stands first.");
             return;
         }
+        if (plugin.getCurrentVideoDownloader() != null) {
+            player.sendMessage("You have to wait for the current download to finish before starting a new one.");
+            return;
+        }
 
-        plugin.stopTask();
-        Task.async(() -> plugin.getVideoDownloader().download(player, videoUrl, disableInterlacing));
+        plugin.stopDisplayTask();
+        Task.async(() -> plugin.download(player, videoUrl, !disableInterlacing));
     }
 
 }

--- a/src/main/java/me/mattstudios/holovid/command/PlayCommand.java
+++ b/src/main/java/me/mattstudios/holovid/command/PlayCommand.java
@@ -1,18 +1,14 @@
 package me.mattstudios.holovid.command;
 
 import me.mattstudios.holovid.Holovid;
-import me.mattstudios.holovid.utils.Task;
 import me.mattstudios.mf.annotations.Command;
 import me.mattstudios.mf.annotations.Completion;
 import me.mattstudios.mf.annotations.Optional;
 import me.mattstudios.mf.annotations.SubCommand;
 import me.mattstudios.mf.base.CommandBase;
-import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
 
 import java.io.File;
-import java.net.MalformedURLException;
-import java.net.URL;
 
 @Command("holovid")
 public final class PlayCommand extends CommandBase {
@@ -47,24 +43,7 @@ public final class PlayCommand extends CommandBase {
             return;
         }
 
-        final YamlConfiguration dataConfig = YamlConfiguration.loadConfiguration(dataFile);
-        final URL url;
-        try {
-            url = new URL(dataConfig.getString("video-url"));
-        } catch (final MalformedURLException e) {
-            e.printStackTrace();
-            return;
-        }
-
-        plugin.stopDownload();
-        plugin.stopDisplayTask();
-
-        final int fps = dataConfig.getInt("fps");
-        final int frames = dataConfig.getInt("frames");
-        final int height = dataConfig.getInt("height");
-        final int width = dataConfig.getInt("width");
-        final boolean requestSoundData = fps * frames < Holovid.MAX_SECONDS_FOR_AUDIO;
-        Task.async(() -> plugin.getVideoProcessor().play(player, videoFile, url, requestSoundData, height, width, frames, fps, !disableInterlace));
+        plugin.playVideoFromSave(player, videoFile, dataFile, !disableInterlace);
     }
 
 }

--- a/src/main/java/me/mattstudios/holovid/command/PlayCommand.java
+++ b/src/main/java/me/mattstudios/holovid/command/PlayCommand.java
@@ -62,7 +62,8 @@ public final class PlayCommand extends CommandBase {
         final int frames = dataConfig.getInt("frames");
         final int height = dataConfig.getInt("height");
         final int width = dataConfig.getInt("width");
-        Task.async(() -> plugin.getVideoProcessor().play(player, videoFile, url, height, width, frames, fps, disableInterlace));
+        final boolean requestSoundData = fps * frames < Holovid.MAX_SECONDS_FOR_AUDIO;
+        Task.async(() -> plugin.getVideoProcessor().play(player, videoFile, url, requestSoundData, height, width, frames, fps, disableInterlace));
     }
 
 }

--- a/src/main/java/me/mattstudios/holovid/command/PlayCommand.java
+++ b/src/main/java/me/mattstudios/holovid/command/PlayCommand.java
@@ -56,14 +56,15 @@ public final class PlayCommand extends CommandBase {
             return;
         }
 
-        plugin.stopTask();
+        plugin.stopDownload();
+        plugin.stopDisplayTask();
 
         final int fps = dataConfig.getInt("fps");
         final int frames = dataConfig.getInt("frames");
         final int height = dataConfig.getInt("height");
         final int width = dataConfig.getInt("width");
         final boolean requestSoundData = fps * frames < Holovid.MAX_SECONDS_FOR_AUDIO;
-        Task.async(() -> plugin.getVideoProcessor().play(player, videoFile, url, requestSoundData, height, width, frames, fps, disableInterlace));
+        Task.async(() -> plugin.getVideoProcessor().play(player, videoFile, url, requestSoundData, height, width, frames, fps, !disableInterlace));
     }
 
 }

--- a/src/main/java/me/mattstudios/holovid/command/SpawnScreenCommand.java
+++ b/src/main/java/me/mattstudios/holovid/command/SpawnScreenCommand.java
@@ -17,6 +17,11 @@ public final class SpawnScreenCommand extends CommandBase {
 
     @SubCommand("spawnscreen")
     public void spawnScreen(final Player player) {
+        if (plugin.getTask() != null) {
+            player.sendMessage("You cannot respawn the hologram while the display is running!");
+            return;
+        }
+
         plugin.spawnHologram(player.getLocation());
         player.sendMessage("Spawned!");
     }

--- a/src/main/java/me/mattstudios/holovid/command/StopCommand.java
+++ b/src/main/java/me/mattstudios/holovid/command/StopCommand.java
@@ -16,8 +16,13 @@ public final class StopCommand extends CommandBase {
     }
 
     @SubCommand("stop")
-    public void spawnScreen(final Player player) {
-        if (!plugin.stopTask()){
+    public void stop(final Player player) {
+        if (plugin.stopDownload()) {
+            player.sendMessage("The current display will be cancelled as soon as possible - you will receive another message when that happens.");
+            return;
+        }
+
+        if (!plugin.stopDisplayTask()) {
             player.sendMessage("There is no video playing at the moment.");
             return;
         }

--- a/src/main/java/me/mattstudios/holovid/display/BufferedDisplayTask.java
+++ b/src/main/java/me/mattstudios/holovid/display/BufferedDisplayTask.java
@@ -10,7 +10,6 @@ import java.util.concurrent.ArrayBlockingQueue;
 public final class BufferedDisplayTask extends DisplayTask {
 
     private final ArrayBlockingQueue<int[][]> frames;
-    private final int bufferCapacity;
     private final long startDelay;
     private final int max;
 
@@ -20,8 +19,7 @@ public final class BufferedDisplayTask extends DisplayTask {
         this.max = max;
 
         // Buffer a few seconds of video beforehand
-        this.bufferCapacity = Holovid.PRE_RENDER_SECONDS * fps;
-        this.frames = new ArrayBlockingQueue<>(bufferCapacity);
+        this.frames = new ArrayBlockingQueue<>(Holovid.PRE_RENDER_SECONDS * fps);
     }
 
     @Override
@@ -44,8 +42,8 @@ public final class BufferedDisplayTask extends DisplayTask {
 
         // Convert to json component
         final IChatBaseComponent[] frameText = new IChatBaseComponent[interlace ? frame.length / 2 : frame.length];
-        if (interlace){
-            for (int y = oddFrame ? 1 : 0; y < frame.length; y += 2){
+        if (interlace) {
+            for (int y = oddFrame ? 1 : 0; y < frame.length; y += 2) {
                 frameText[y / 2] = dataToComponent(frame[y]);
             }
         } else {
@@ -58,10 +56,6 @@ public final class BufferedDisplayTask extends DisplayTask {
 
     public ArrayBlockingQueue<int[][]> getFrameQueue() {
         return frames;
-    }
-
-    public boolean isQueueFull() {
-        return frames.size() >= bufferCapacity;
     }
 
     private IChatBaseComponent dataToComponent(final int[] row) {

--- a/src/main/java/me/mattstudios/holovid/display/BufferedDisplayTask.java
+++ b/src/main/java/me/mattstudios/holovid/display/BufferedDisplayTask.java
@@ -5,11 +5,8 @@ import net.minecraft.server.v1_16_R1.ChatBaseComponent;
 import net.minecraft.server.v1_16_R1.ChatComponentText;
 import net.minecraft.server.v1_16_R1.IChatBaseComponent;
 
-import java.util.concurrent.ArrayBlockingQueue;
-
 public final class BufferedDisplayTask extends DisplayTask {
 
-    private final ArrayBlockingQueue<int[][]> frames;
     private final long startDelay;
     private final int max;
 
@@ -17,9 +14,6 @@ public final class BufferedDisplayTask extends DisplayTask {
         super(plugin, repeat, fps, interlace);
         this.startDelay = startDelay;
         this.max = max;
-
-        // Buffer a few seconds of video beforehand
-        this.frames = new ArrayBlockingQueue<>(Holovid.PRE_RENDER_SECONDS * fps);
     }
 
     @Override
@@ -38,7 +32,7 @@ public final class BufferedDisplayTask extends DisplayTask {
     @Override
     protected IChatBaseComponent[] getCurrentFrame() throws InterruptedException {
         // Block until the frame is processed
-        final int[][] frame = frames.take();
+        final int[][] frame = plugin.getVideoProcessor().getFrameQueue().take();
 
         // Convert to json component
         final IChatBaseComponent[] frameText = new IChatBaseComponent[interlace ? frame.length / 2 : frame.length];
@@ -52,10 +46,6 @@ public final class BufferedDisplayTask extends DisplayTask {
             }
         }
         return frameText;
-    }
-
-    public ArrayBlockingQueue<int[][]> getFrameQueue() {
-        return frames;
     }
 
     private IChatBaseComponent dataToComponent(final int[] row) {

--- a/src/main/java/me/mattstudios/holovid/display/DisplayTask.java
+++ b/src/main/java/me/mattstudios/holovid/display/DisplayTask.java
@@ -30,7 +30,8 @@ public abstract class DisplayTask implements Runnable {
     protected DisplayTask(final Holovid plugin, final boolean repeat, final int fps, final boolean interlace) {
         this.plugin = plugin;
         this.repeat = repeat;
-        this.frameDelayNanos = (long) ((1000D / fps) * 1_000_000);
+        // 1000ms to nanos
+        this.frameDelayNanos = (1000L * 1_000_000L) / fps;
         this.interlace = interlace;
     }
 
@@ -83,9 +84,9 @@ public abstract class DisplayTask implements Runnable {
 
         // Set hologram lines
         final List<HologramLine> lines = plugin.getHologram().getLines();
-        if (interlace){
+        if (interlace) {
             final int x = oddFrame ? 1 : 0;
-            for (int i = 0; i < frame.length ; i++) {
+            for (int i = 0; i < frame.length; i++) {
                 final IChatBaseComponent line = frame[i];
                 final HologramLine hologramLine = lines.get(x + (i * 2));
 

--- a/src/main/java/me/mattstudios/holovid/display/DisplayTask.java
+++ b/src/main/java/me/mattstudios/holovid/display/DisplayTask.java
@@ -14,7 +14,7 @@ import java.util.concurrent.locks.ReentrantLock;
 
 public abstract class DisplayTask implements Runnable {
 
-    private final Holovid plugin;
+    protected final Holovid plugin;
     private final long frameDelayNanos;
     private final boolean repeat;
     protected final boolean interlace;

--- a/src/main/java/me/mattstudios/holovid/display/DisplayTask.java
+++ b/src/main/java/me/mattstudios/holovid/display/DisplayTask.java
@@ -103,7 +103,7 @@ public abstract class DisplayTask implements Runnable {
 
         if (++frameCounter == getMaxFrames()) {
             if (!repeat) {
-                plugin.stopTask();
+                plugin.stopDisplayTask();
                 return;
             }
 

--- a/src/main/java/me/mattstudios/holovid/display/TaskInfo.java
+++ b/src/main/java/me/mattstudios/holovid/display/TaskInfo.java
@@ -1,0 +1,32 @@
+package me.mattstudios.holovid.display;
+
+public final class TaskInfo {
+
+    private final int frames;
+    private final int height;
+    private final int fps;
+    private final boolean interlacing;
+
+    public TaskInfo(final int frames, final int height, final int fps, final boolean interlacing) {
+        this.frames = frames;
+        this.height = height;
+        this.fps = fps;
+        this.interlacing = interlacing;
+    }
+
+    public int getFrames() {
+        return frames;
+    }
+
+    public int getHeight() {
+        return height;
+    }
+
+    public int getFps() {
+        return fps;
+    }
+
+    public boolean interlacing() {
+        return interlacing;
+    }
+}

--- a/src/main/java/me/mattstudios/holovid/download/AudioProcessor.java
+++ b/src/main/java/me/mattstudios/holovid/download/AudioProcessor.java
@@ -1,0 +1,72 @@
+package me.mattstudios.holovid.download;
+
+import me.mattstudios.holovid.Holovid;
+import me.mattstudios.holovid.display.TaskInfo;
+import org.bukkit.entity.Player;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+public final class AudioProcessor {
+
+    private final Set<UUID> awaitingResourcepack = new HashSet<>();
+    private final Holovid plugin;
+    private TaskInfo taskInfo;
+    private int awaitingTask = -1;
+
+    public AudioProcessor(final Holovid plugin) {
+        this.plugin = plugin;
+    }
+
+    public void process(final Player player, final URL videoUrl, final TaskInfo taskInfo) throws IOException {
+        final String stringUrl = videoUrl.toExternalForm();
+        final HttpURLConnection c = (HttpURLConnection) new URL("https://holov.id/resourcepack/download/resource?videoUrl=" + stringUrl).openConnection();
+        final String downloadLink;
+        final InputStream in = c.getInputStream();
+        if (c.getResponseCode() != 200) {
+            throw new RuntimeException("Error requestion audio data for " + videoUrl);
+        }
+
+        try (final BufferedReader reader = new BufferedReader(new InputStreamReader(in))) {
+            downloadLink = reader.readLine();
+        }
+
+        player.sendMessage("The video display will start once all players in tracking range have accepted and downloaded the resourcepack!");
+
+        final String hash = stringUrl.length() > 40 ? stringUrl.substring(0, 40) : stringUrl;
+        for (final Player p : plugin.getHologram().getViewers()) {
+            p.setResourcePack(downloadLink, hash);
+            awaitingResourcepack.add(p.getUniqueId());
+        }
+
+        this.taskInfo = taskInfo;
+
+        awaitingTask = plugin.getServer().getScheduler().runTaskLater(plugin, () -> {
+            // Force start after an amount of time if not all players have accepted/downloaded the rp
+            if (!awaitingResourcepack.isEmpty()) {
+                awaitingResourcepack.clear();
+                startTask();
+            }
+        }, 20 * 15).getTaskId();
+    }
+
+    public void removeAwaiting(final Player player) {
+        if (awaitingResourcepack.remove(player.getUniqueId()) && awaitingResourcepack.isEmpty()) {
+            plugin.getServer().getScheduler().cancelTask(awaitingTask);
+            startTask();
+        }
+    }
+
+    private void startTask() {
+        plugin.startBufferedTask(0, taskInfo.getFrames(), taskInfo.getHeight(), taskInfo.getFps(), taskInfo.interlacing());
+        taskInfo = null;
+        awaitingTask = -1;
+    }
+}

--- a/src/main/java/me/mattstudios/holovid/download/AudioProcessor.java
+++ b/src/main/java/me/mattstudios/holovid/download/AudioProcessor.java
@@ -2,6 +2,9 @@ package me.mattstudios.holovid.download;
 
 import me.mattstudios.holovid.Holovid;
 import me.mattstudios.holovid.display.TaskInfo;
+import me.mattstudios.holovid.hologram.Hologram;
+import org.bukkit.Location;
+import org.bukkit.SoundCategory;
 import org.bukkit.entity.Player;
 
 import java.io.BufferedReader;
@@ -57,17 +60,22 @@ public final class AudioProcessor {
         }, 20 * 15).getTaskId();
     }
 
+    private void startTask() {
+        plugin.startBufferedTask(0, taskInfo.getFrames(), taskInfo.getHeight(), taskInfo.getFps(), taskInfo.interlacing());
+        taskInfo = null;
+        awaitingTask = -1;
+
+        final Hologram hologram = plugin.getHologram();
+        final Location location = hologram.getBaseLocation().add(0, 0.225D * (hologram.getLines().size() / 2D), 0);
+        // Set a high volume to workaround attenuation
+        location.getWorld().playSound(location, "holovid.video", SoundCategory.MASTER, 40, 1);
+    }
+
     public void removeAwaiting(final Player player) {
         if (awaitingResourcepack.remove(player.getUniqueId()) && awaitingResourcepack.isEmpty()) {
             plugin.getServer().getScheduler().cancelTask(awaitingTask);
             startTask();
         }
-    }
-
-    private void startTask() {
-        plugin.startBufferedTask(0, taskInfo.getFrames(), taskInfo.getHeight(), taskInfo.getFps(), taskInfo.interlacing());
-        taskInfo = null;
-        awaitingTask = -1;
     }
 
     public void stopCurrentTask() {

--- a/src/main/java/me/mattstudios/holovid/download/AudioProcessor.java
+++ b/src/main/java/me/mattstudios/holovid/download/AudioProcessor.java
@@ -69,4 +69,12 @@ public final class AudioProcessor {
         taskInfo = null;
         awaitingTask = -1;
     }
+
+    public void stopCurrentTask() {
+        if (awaitingTask != -1) {
+            plugin.getServer().getScheduler().cancelTask(awaitingTask);
+            taskInfo = null;
+            awaitingResourcepack.clear();
+        }
+    }
 }

--- a/src/main/java/me/mattstudios/holovid/download/VideoDownloader.java
+++ b/src/main/java/me/mattstudios/holovid/download/VideoDownloader.java
@@ -62,6 +62,10 @@ public abstract class VideoDownloader {
         plugin.getVideoProcessor().play(player, videoFile, videoUrl, prepareAudio, plugin.getDisplayHeight(), plugin.getDisplayWidth(), frames, fps, interlace);
     }
 
+    protected File getOutputDirForTitle(final String title) {
+        return new File(plugin.getDataFolder(), "saves/" + title.replaceAll("[^A-Za-z0-9]", ""));
+    }
+
     public void cancelBeforeDisplay() {
         cancelBeforeDisplay = true;
     }

--- a/src/main/java/me/mattstudios/holovid/download/VideoDownloader.java
+++ b/src/main/java/me/mattstudios/holovid/download/VideoDownloader.java
@@ -25,7 +25,7 @@ public abstract class VideoDownloader {
     public abstract void download(Player player, URL videoUrl, final boolean disableinterlacing);
 
 
-    protected void saveDataAndPlay(final Player player, final File videoFile, final URL videoUrl, final File outputDir,
+    protected void saveDataAndPlay(final Player player, final File videoFile, final URL videoUrl, final File outputDir, final boolean prepareAudio,
                                    final int frames, final int fps, final boolean disableInterlacing) throws IOException {
         // Save data about the video format
         final YamlConfiguration dataConfig = new YamlConfiguration();
@@ -37,7 +37,7 @@ public abstract class VideoDownloader {
         dataConfig.save(new File(outputDir, "data.yml"));
 
         // Play the video!
-        plugin.getVideoProcessor().play(player, videoFile, videoUrl, plugin.getDisplayHeight(), plugin.getDisplayWidth(), frames, fps, disableInterlacing);
+        plugin.getVideoProcessor().play(player, videoFile, videoUrl, prepareAudio, plugin.getDisplayHeight(), plugin.getDisplayWidth(), frames, fps, disableInterlacing);
     }
 
 }

--- a/src/main/java/me/mattstudios/holovid/download/VideoProcessor.java
+++ b/src/main/java/me/mattstudios/holovid/download/VideoProcessor.java
@@ -44,7 +44,7 @@ public final class VideoProcessor {
                      final int height, final int width, final int frames, final int fps, final boolean interlace) {
         Preconditions.checkArgument(!Bukkit.isPrimaryThread());
 
-        if (prepareAudio) {
+        if (prepareAudio && plugin.shouldRequestAudio()) {
             try {
                 player.sendMessage("Downloading audio data on an external host...");
                 plugin.getAudioProcessor().process(player, videoUrl, new TaskInfo(frames, height, fps, interlace));

--- a/src/main/java/me/mattstudios/holovid/download/VideoProcessor.java
+++ b/src/main/java/me/mattstudios/holovid/download/VideoProcessor.java
@@ -39,13 +39,13 @@ public final class VideoProcessor {
      * Should ALWAYS be called async!
      */
     public void play(final Player player, final File videoFile, final URL videoUrl, boolean prepareAudio,
-                     final int height, final int width, final int frames, final int fps, final boolean disableInterlacing) {
+                     final int height, final int width, final int frames, final int fps, final boolean interlace) {
         Preconditions.checkArgument(!Bukkit.isPrimaryThread());
 
         if (prepareAudio) {
             try {
                 player.sendMessage("Downloading audio data on an external host...");
-                plugin.getAudioProcessor().process(player, videoUrl, new TaskInfo(frames, height, fps, !disableInterlacing));
+                plugin.getAudioProcessor().process(player, videoUrl, new TaskInfo(frames, height, fps, interlace));
             } catch (final Exception e) {
                 prepareAudio = false;
                 player.sendMessage("Error trying to get sounddata - skipping to video display!");
@@ -53,7 +53,6 @@ public final class VideoProcessor {
             }
         }
 
-        //TODO use videourl to request a resourcepack with sound
         try {
             player.sendMessage("Processing and displaying video...");
 
@@ -106,7 +105,7 @@ public final class VideoProcessor {
             // Start task if no audio has to be processed
             if (!prepareAudio) {
                 // Start instant replay slightly delayed
-                plugin.startBufferedTask(2000, frames, height, fps, !disableInterlacing);
+                plugin.startBufferedTask(2000, frames, height, fps, interlace);
             }
 
             // Resize and save images in parallel to the frame grabbing

--- a/src/main/java/me/mattstudios/holovid/download/VideoProcessor.java
+++ b/src/main/java/me/mattstudios/holovid/download/VideoProcessor.java
@@ -18,6 +18,7 @@ import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.channels.ClosedByInterruptException;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -75,6 +76,8 @@ public final class VideoProcessor {
                     final Picture picture;
                     try {
                         picture = grab.getNativeFrame();
+                    } catch (final ClosedByInterruptException e) {
+                        return;
                     } catch (final IOException e) {
                         e.printStackTrace();
                         // Interrupt threads on error
@@ -155,7 +158,6 @@ public final class VideoProcessor {
         }
 
         final BufferedDisplayTask task = (BufferedDisplayTask) plugin.getTask();
-        if (task == null) return;
 
         // Block until the frame can be placed in the queue
         task.getFrameQueue().put(frame);

--- a/src/main/java/me/mattstudios/holovid/download/VideoProcessor.java
+++ b/src/main/java/me/mattstudios/holovid/download/VideoProcessor.java
@@ -44,7 +44,8 @@ public final class VideoProcessor {
                      final int height, final int width, final int frames, final int fps, final boolean interlace) {
         Preconditions.checkArgument(!Bukkit.isPrimaryThread());
 
-        if (prepareAudio && plugin.shouldRequestAudio()) {
+        prepareAudio = prepareAudio && plugin.shouldRequestAudio();
+        if (prepareAudio) {
             try {
                 player.sendMessage("Downloading audio data on an external host...");
                 plugin.getAudioProcessor().process(player, videoUrl, new TaskInfo(frames, height, fps, interlace));

--- a/src/main/java/me/mattstudios/holovid/download/VideoProcessor.java
+++ b/src/main/java/me/mattstudios/holovid/download/VideoProcessor.java
@@ -94,7 +94,15 @@ public final class VideoProcessor {
                     if (Thread.interrupted()) return;
 
                     // Block if there already are a lot of pre-buffered frames
+                    final BufferedDisplayTask task = (BufferedDisplayTask) plugin.getTask();
                     try {
+                        if (task != null) {
+                            // Also wait for the frames queue as well - hack to fix random speedups when the frame queue is full
+                            while (task.getFrameQueue().remainingCapacity() <= 1) {
+                                Thread.sleep(5);
+                            }
+                        }
+
                         pictures.put(last);
                     } catch (final InterruptedException e) {
                         return;
@@ -161,6 +169,7 @@ public final class VideoProcessor {
         }
 
         final BufferedDisplayTask task = (BufferedDisplayTask) plugin.getTask();
+        if (task == null) return;
 
         // Block until the frame can be placed in the queue
         task.getFrameQueue().put(frame);

--- a/src/main/java/me/mattstudios/holovid/download/YouTubeDownloader.java
+++ b/src/main/java/me/mattstudios/holovid/download/YouTubeDownloader.java
@@ -6,9 +6,7 @@ import com.github.kiulian.downloader.model.YoutubeVideo;
 import com.github.kiulian.downloader.model.formats.AudioVideoFormat;
 import com.github.kiulian.downloader.model.formats.VideoFormat;
 import com.github.kiulian.downloader.model.quality.VideoQuality;
-import com.google.common.base.Preconditions;
 import me.mattstudios.holovid.Holovid;
-import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
 import java.io.File;
@@ -26,14 +24,10 @@ public final class YouTubeDownloader extends VideoDownloader {
         downloader.setParserRequestProperty("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Safari/537.36");
     }
 
-    public void download(final Player player, final URL videoUrl, final boolean disableInterlacing) {
-        Preconditions.checkArgument(!Bukkit.isPrimaryThread());
-
+    public void download0(final Player player, final URL videoUrl, final boolean interlace) {
         // Gets the video ID
         final String id = videoUrl.getQuery().substring(2);
         try {
-            player.sendMessage("Downloading video...");
-
             final YoutubeVideo video = downloader.getVideo(id);
 
             // Gets the video format and audio format
@@ -59,7 +53,7 @@ public final class YouTubeDownloader extends VideoDownloader {
             final int fps = videoQuality.get(0).fps();
             final int frames = fps * video.details().lengthSeconds();
             final boolean prepareAudio = fps * frames < Holovid.MAX_SECONDS_FOR_AUDIO;
-            saveDataAndPlay(player, videoFile, videoUrl, outputDir, prepareAudio, frames, fps, disableInterlacing);
+            saveDataAndPlay(player, videoFile, videoUrl, outputDir, prepareAudio, frames, fps, interlace);
         } catch (final YoutubeException | IOException e) {
             player.sendMessage("Error downloading the video!");
             e.printStackTrace();

--- a/src/main/java/me/mattstudios/holovid/download/YouTubeDownloader.java
+++ b/src/main/java/me/mattstudios/holovid/download/YouTubeDownloader.java
@@ -58,7 +58,7 @@ public final class YouTubeDownloader extends VideoDownloader {
             final List<VideoFormat> videoQuality = video.findVideoWithQuality(VideoQuality.tiny);
             final int fps = videoQuality.get(0).fps();
             final int frames = fps * video.details().lengthSeconds();
-            final boolean prepareAudio = fps * frames < Holovid.MAX_SECONDS_FOR_AUDIO;
+            final boolean prepareAudio = frames / fps < Holovid.MAX_SECONDS_FOR_AUDIO;
             saveDataAndPlay(player, videoFile, videoUrl, outputDir, prepareAudio, frames, fps, interlace);
         } catch (final YoutubeException | IOException e) {
             player.sendMessage("Error downloading the video!");

--- a/src/main/java/me/mattstudios/holovid/download/YouTubeDownloader.java
+++ b/src/main/java/me/mattstudios/holovid/download/YouTubeDownloader.java
@@ -58,7 +58,8 @@ public final class YouTubeDownloader extends VideoDownloader {
             // Calculates how many frames the video has
             final int fps = videoQuality.get(0).fps();
             final int frames = fps * video.details().lengthSeconds();
-            saveDataAndPlay(player, videoFile, videoUrl, outputDir, frames, fps, disableInterlacing);
+            final boolean prepareAudio = fps * frames < Holovid.MAX_SECONDS_FOR_AUDIO;
+            saveDataAndPlay(player, videoFile, videoUrl, outputDir, prepareAudio, frames, fps, disableInterlacing);
         } catch (final YoutubeException | IOException e) {
             player.sendMessage("Error downloading the video!");
             e.printStackTrace();

--- a/src/main/java/me/mattstudios/holovid/listener/ResourcePackStatusListener.java
+++ b/src/main/java/me/mattstudios/holovid/listener/ResourcePackStatusListener.java
@@ -1,0 +1,35 @@
+package me.mattstudios.holovid.listener;
+
+import me.mattstudios.holovid.Holovid;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.event.player.PlayerResourcePackStatusEvent;
+
+public final class ResourcePackStatusListener implements Listener {
+
+    private final Holovid plugin;
+
+    public ResourcePackStatusListener(final Holovid plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler
+    public void resourcepackStatus(final PlayerResourcePackStatusEvent event) {
+        final Player player = event.getPlayer();
+        switch (event.getStatus()) {
+            case SUCCESSFULLY_LOADED:
+            case DECLINED:
+            case FAILED_DOWNLOAD:
+                // Contains check is done there - remove awaiting status of the player
+                plugin.getAudioProcessor().removeAwaiting(player);
+                break;
+        }
+    }
+
+    @EventHandler
+    public void playerQuit(final PlayerQuitEvent event) {
+        plugin.getAudioProcessor().removeAwaiting(event.getPlayer());
+    }
+}

--- a/src/main/java/me/mattstudios/holovid/listener/ResourcePackStatusListener.java
+++ b/src/main/java/me/mattstudios/holovid/listener/ResourcePackStatusListener.java
@@ -18,18 +18,15 @@ public final class ResourcePackStatusListener implements Listener {
     @EventHandler
     public void resourcepackStatus(final PlayerResourcePackStatusEvent event) {
         final Player player = event.getPlayer();
-        switch (event.getStatus()) {
-            case SUCCESSFULLY_LOADED:
-            case DECLINED:
-            case FAILED_DOWNLOAD:
-                // Contains check is done there - remove awaiting status of the player
-                plugin.getAudioProcessor().removeAwaiting(player);
-                break;
+        if (event.getStatus() != PlayerResourcePackStatusEvent.Status.ACCEPTED) {
+            // Contains check is done there - remove awaiting status of the player if denied or successfully loaded
+            plugin.getAudioProcessor().removeAwaiting(player);
         }
     }
 
     @EventHandler
     public void playerQuit(final PlayerQuitEvent event) {
-        plugin.getAudioProcessor().removeAwaiting(event.getPlayer());
+        final Player player = event.getPlayer();
+        plugin.getAudioProcessor().removeAwaiting(player);
     }
 }

--- a/src/main/java/me/mattstudios/holovid/model/ResourcePackResult.java
+++ b/src/main/java/me/mattstudios/holovid/model/ResourcePackResult.java
@@ -1,0 +1,20 @@
+package me.mattstudios.holovid.model;
+
+public final class ResourcePackResult {
+
+    private final String url;
+    private final String hash;
+
+    public ResourcePackResult(final String url, final String hash) {
+        this.url = url;
+        this.hash = hash;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public String getHash() {
+        return hash;
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -2,6 +2,3 @@
 # You may go lower or higher (e.g. 256x144), but higher values will cause the client to have a harder time processing all of the incoming data.
 display-height: 72
 display-width: 128
-
-# Disable this if the external audio server is down / you don't want to have audio resourcepacks.
-request-audio: true

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -2,3 +2,6 @@
 # You may go lower or higher (e.g. 256x144), but higher values will cause the client to have a harder time processing all of the incoming data.
 display-height: 72
 display-width: 128
+
+# Disable this if the external audio server is down / you don't want to have audio resourcepacks.
+request-audio: true

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,2 +1,4 @@
-display-height: 144
-display-width: 256
+# 128 are the recommended values.
+# You may go lower or higher (e.g. 256x144), but higher values will cause the client to have a harder time processing all of the incoming data.
+display-height: 72
+display-width: 128


### PR DESCRIPTION
The config option to enable the audio request is not yet put in, so that it's effectively completely disabled for now.

Improvements/fixes are:
* Stopping the display properly works now
* The stop command now also works during the downloading
* The video doesn't randomly speedup anymore
* Close the filereader, so that files can be deleted (and free ze memory)
* Don't let the user respawn the hologram while the display is running