### PR TITLE
Add support for 1.19.x & 1.20.x, and other changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ allprojects {
     dependencies {
 
         // Paper
-        compileOnly 'io.papermc.paper:paper-api:1.19.1-R0.1-SNAPSHOT'
+        compileOnly "io.papermc.paper:paper-api:1.20.1-R0.1-SNAPSHOT"
         // ProtocolLib
         compileOnly "com.comphenix.protocol:ProtocolLib:5.0.0-SNAPSHOT"
 

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ allprojects {
         // Paper
         compileOnly 'io.papermc.paper:paper-api:1.19.1-R0.1-SNAPSHOT'
         // ProtocolLib
-        compileOnly "com.comphenix.protocol:ProtocolLib:4.8.0"
+        compileOnly "com.comphenix.protocol:ProtocolLib:5.0.0-SNAPSHOT"
 
         // JetBrains annotations
         compileOnly "org.jetbrains:annotations:22.0.0"
@@ -40,6 +40,7 @@ allprojects {
         implementation "org.jcodec:jcodec-javase:0.2.5"
         implementation "net.coobird:thumbnailator:0.4.17"
 
+
     }
 
     sourceCompatibility = JavaVersion.VERSION_17
@@ -48,7 +49,6 @@ allprojects {
     compileJava {
         options.compilerArgs += ["-parameters"]
         options.fork = true
-        options.forkOptions.executable = 'javac'
         options.encoding = 'UTF-8'
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ allprojects {
     dependencies {
 
         // Paper
-        compileOnly 'io.papermc.paper:paper-api:1.18.2-R0.1-SNAPSHOT'
+        compileOnly 'io.papermc.paper:paper-api:1.19.1-R0.1-SNAPSHOT'
         // ProtocolLib
         compileOnly "com.comphenix.protocol:ProtocolLib:4.8.0"
 
@@ -33,7 +33,7 @@ allprojects {
 
         implementation "commons-validator:commons-validator:1.7"
 
-        implementation "com.github.sealedtx:java-youtube-downloader:3.0.2"
+        implementation "com.github.sealedtx:java-youtube-downloader:3.2.3"
 
         implementation "org.jcodec:jcodec:0.2.5"
         implementation "org.jcodec:jcodec-android:0.2.5"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/me/mattstudios/holovid/compatability/CompatibilityManager.java
+++ b/src/main/java/me/mattstudios/holovid/compatability/CompatibilityManager.java
@@ -37,7 +37,9 @@ public class CompatibilityManager {
             Wrapper1_19_1.class,
             Wrapper1_19_2.class,
             Wrapper1_19_3.class,
-            Wrapper1_19_4.class
+            Wrapper1_19_4.class,
+            Wrapper1_20.class,
+            Wrapper1_20_1.class
     );
 
     public CompatibilityManager(ProtocolManager manager, Holovid holovid){

--- a/src/main/java/me/mattstudios/holovid/compatability/CompatibilityManager.java
+++ b/src/main/java/me/mattstudios/holovid/compatability/CompatibilityManager.java
@@ -32,7 +32,9 @@ public class CompatibilityManager {
             Wrapper1_17.class,
             Wrapper1_17_1.class,
             Wrapper1_18_1.class,
-            Wrapper1_18_2.class
+            Wrapper1_18_2.class,
+            Wrapper1_19.class,
+            Wrapper1_19_1.class
     );
 
     public CompatibilityManager(ProtocolManager manager, Holovid holovid){

--- a/src/main/java/me/mattstudios/holovid/compatability/CompatibilityManager.java
+++ b/src/main/java/me/mattstudios/holovid/compatability/CompatibilityManager.java
@@ -34,7 +34,10 @@ public class CompatibilityManager {
             Wrapper1_18_1.class,
             Wrapper1_18_2.class,
             Wrapper1_19.class,
-            Wrapper1_19_1.class
+            Wrapper1_19_1.class,
+            Wrapper1_19_2.class,
+            Wrapper1_19_3.class,
+            Wrapper1_19_4.class
     );
 
     public CompatibilityManager(ProtocolManager manager, Holovid holovid){

--- a/src/main/java/me/mattstudios/holovid/compatability/wrappers/Wrapper1_16.java
+++ b/src/main/java/me/mattstudios/holovid/compatability/wrappers/Wrapper1_16.java
@@ -12,7 +12,10 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 
 import java.lang.reflect.Field;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class Wrapper1_16 implements CompatibilityWrapper {

--- a/src/main/java/me/mattstudios/holovid/compatability/wrappers/Wrapper1_17.java
+++ b/src/main/java/me/mattstudios/holovid/compatability/wrappers/Wrapper1_17.java
@@ -16,18 +16,10 @@ public class Wrapper1_17 extends Wrapper1_16{
     }
 
     private AtomicInteger ENTITY_ID;
-    private String NMS;
-
-    public Class<?> getNMSClass(final String className) throws ClassNotFoundException {
-        return Class.forName(NMS + className);
-    }
 
     @Override
     public int getUniqueEntityId() {
         if (ENTITY_ID == null){
-            final String packageName = Bukkit.getServer().getClass().getPackage().getName();
-            final String SERVER_VERSION = packageName.substring(packageName.lastIndexOf('.') + 1);
-            NMS = "net.minecraft.server." + SERVER_VERSION + ".";
             try {
                 final Field entityCount = Class.forName("net.minecraft.world.entity.Entity").getDeclaredField("b");
                 entityCount.setAccessible(true);

--- a/src/main/java/me/mattstudios/holovid/compatability/wrappers/Wrapper1_17.java
+++ b/src/main/java/me/mattstudios/holovid/compatability/wrappers/Wrapper1_17.java
@@ -2,7 +2,6 @@ package me.mattstudios.holovid.compatability.wrappers;
 
 import com.comphenix.protocol.PacketType;
 import com.comphenix.protocol.events.PacketContainer;
-import org.bukkit.Bukkit;
 
 import java.lang.reflect.Field;
 import java.util.concurrent.atomic.AtomicInteger;

--- a/src/main/java/me/mattstudios/holovid/compatability/wrappers/Wrapper1_18_2.java
+++ b/src/main/java/me/mattstudios/holovid/compatability/wrappers/Wrapper1_18_2.java
@@ -1,7 +1,5 @@
 package me.mattstudios.holovid.compatability.wrappers;
 
-import org.bukkit.Bukkit;
-
 import java.lang.reflect.Field;
 import java.util.concurrent.atomic.AtomicInteger;
 

--- a/src/main/java/me/mattstudios/holovid/compatability/wrappers/Wrapper1_19.java
+++ b/src/main/java/me/mattstudios/holovid/compatability/wrappers/Wrapper1_19.java
@@ -1,0 +1,27 @@
+package me.mattstudios.holovid.compatability.wrappers;
+
+import com.comphenix.protocol.PacketType;
+import com.comphenix.protocol.events.PacketContainer;
+import org.bukkit.Location;
+
+import java.util.UUID;
+
+public class Wrapper1_19 extends Wrapper1_18_2 {
+
+    public PacketContainer createSpawnPacket(int entityId, Location location) {
+        final PacketContainer packet = new PacketContainer(PacketType.Play.Server.SPAWN_ENTITY);
+
+        packet.getIntegers()
+                .write(0, entityId)
+                .write(1, 1); // Armor Stand
+        packet.getUUIDs()
+                .write(0, UUID.randomUUID());
+        packet.getDoubles() //Cords
+                .write(0, location.getX())
+                .write(1, location.getY())
+                .write(2, location.getZ());
+
+        return packet;
+    }
+
+}

--- a/src/main/java/me/mattstudios/holovid/compatability/wrappers/Wrapper1_19.java
+++ b/src/main/java/me/mattstudios/holovid/compatability/wrappers/Wrapper1_19.java
@@ -3,6 +3,7 @@ package me.mattstudios.holovid.compatability.wrappers;
 import com.comphenix.protocol.PacketType;
 import com.comphenix.protocol.events.PacketContainer;
 import org.bukkit.Location;
+import org.bukkit.entity.EntityType;
 
 import java.util.UUID;
 
@@ -12,8 +13,9 @@ public class Wrapper1_19 extends Wrapper1_18_2 {
         final PacketContainer packet = new PacketContainer(PacketType.Play.Server.SPAWN_ENTITY);
 
         packet.getIntegers()
-                .write(0, entityId)
-                .write(1, 1); // Armor Stand
+                .write(0, entityId);
+        packet.getEntityTypeModifier()
+                .write(0, EntityType.ARMOR_STAND);
         packet.getUUIDs()
                 .write(0, UUID.randomUUID());
         packet.getDoubles() //Cords

--- a/src/main/java/me/mattstudios/holovid/compatability/wrappers/Wrapper1_19_1.java
+++ b/src/main/java/me/mattstudios/holovid/compatability/wrappers/Wrapper1_19_1.java
@@ -1,5 +1,5 @@
 package me.mattstudios.holovid.compatability.wrappers;
 
-public class Wrapper1_18_1 extends Wrapper1_17_1 {
+public class Wrapper1_19_1 extends Wrapper1_19 {
 
 }

--- a/src/main/java/me/mattstudios/holovid/compatability/wrappers/Wrapper1_19_2.java
+++ b/src/main/java/me/mattstudios/holovid/compatability/wrappers/Wrapper1_19_2.java
@@ -1,0 +1,4 @@
+package me.mattstudios.holovid.compatability.wrappers;
+
+public class Wrapper1_19_2 extends Wrapper1_19_1 {
+}

--- a/src/main/java/me/mattstudios/holovid/compatability/wrappers/Wrapper1_19_3.java
+++ b/src/main/java/me/mattstudios/holovid/compatability/wrappers/Wrapper1_19_3.java
@@ -5,17 +5,12 @@ import com.comphenix.protocol.events.PacketContainer;
 import com.comphenix.protocol.wrappers.WrappedChatComponent;
 import com.comphenix.protocol.wrappers.WrappedDataValue;
 import com.comphenix.protocol.wrappers.WrappedDataWatcher;
-import com.comphenix.protocol.wrappers.WrappedWatchableObject;
-import com.google.common.collect.Lists;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
-import org.bukkit.Location;
-import org.bukkit.entity.EntityType;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 
 public class Wrapper1_19_3 extends Wrapper1_19_2 {
     private static final WrappedDataWatcher.Serializer chatSerializer = WrappedDataWatcher.Registry.getChatComponentSerializer(true);

--- a/src/main/java/me/mattstudios/holovid/compatability/wrappers/Wrapper1_19_3.java
+++ b/src/main/java/me/mattstudios/holovid/compatability/wrappers/Wrapper1_19_3.java
@@ -1,0 +1,58 @@
+package me.mattstudios.holovid.compatability.wrappers;
+
+import com.comphenix.protocol.PacketType;
+import com.comphenix.protocol.events.PacketContainer;
+import com.comphenix.protocol.wrappers.WrappedChatComponent;
+import com.comphenix.protocol.wrappers.WrappedDataValue;
+import com.comphenix.protocol.wrappers.WrappedDataWatcher;
+import com.comphenix.protocol.wrappers.WrappedWatchableObject;
+import com.google.common.collect.Lists;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
+import org.bukkit.Location;
+import org.bukkit.entity.EntityType;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public class Wrapper1_19_3 extends Wrapper1_19_2 {
+    private static final WrappedDataWatcher.Serializer chatSerializer = WrappedDataWatcher.Registry.getChatComponentSerializer(true);
+
+    public PacketContainer createMetadataPacket(int entityId){
+        final PacketContainer metaDataPacket = new PacketContainer(PacketType.Play.Server.ENTITY_METADATA);
+
+        metaDataPacket.getIntegers()
+                .write(0, entityId);
+
+        final WrappedChatComponent wrappedChatComponent = WrappedChatComponent.fromJson(GsonComponentSerializer.gson().serialize(Component.text("Waiting for video...")));
+
+        final List<WrappedDataValue> content = new ArrayList<>();
+        content.add(new WrappedDataValue(0, WrappedDataWatcher.Registry.get(Byte.class), (byte) 40));
+        content.add(new WrappedDataValue(2, chatSerializer, Optional.of(wrappedChatComponent.getHandle())));
+        content.add(new WrappedDataValue(3, WrappedDataWatcher.Registry.get(Boolean.class), true));
+        content.add(new WrappedDataValue(5, WrappedDataWatcher.Registry.get(Boolean.class), true));
+
+        metaDataPacket.getDataValueCollectionModifier()
+                .write(0, content);
+
+        return metaDataPacket;
+    }
+
+    public PacketContainer getUpdatePacket(int entityId, final Component component) {
+        final PacketContainer packetContainer = new PacketContainer(PacketType.Play.Server.ENTITY_METADATA);
+
+        packetContainer.getIntegers()
+                .write(0, entityId);
+
+        final WrappedChatComponent wrappedChatComponent = WrappedChatComponent.fromJson(GsonComponentSerializer.gson().serialize(component));
+        final List<WrappedDataValue> object = new ArrayList<>();
+        object.add(new WrappedDataValue(2, chatSerializer, Optional.of(wrappedChatComponent.getHandle())));
+
+        packetContainer.getDataValueCollectionModifier()
+                .write(0, object);
+
+        return packetContainer;
+    }
+}

--- a/src/main/java/me/mattstudios/holovid/compatability/wrappers/Wrapper1_19_4.java
+++ b/src/main/java/me/mattstudios/holovid/compatability/wrappers/Wrapper1_19_4.java
@@ -1,11 +1,9 @@
 package me.mattstudios.holovid.compatability.wrappers;
 
-import org.bukkit.Bukkit;
-
 import java.lang.reflect.Field;
 import java.util.concurrent.atomic.AtomicInteger;
 
-public class Wrapper1_18_2 extends Wrapper1_18_1 {
+public class Wrapper1_19_4 extends Wrapper1_19_3 {
 
     private AtomicInteger ENTITY_ID;
 
@@ -13,7 +11,7 @@ public class Wrapper1_18_2 extends Wrapper1_18_1 {
     public int getUniqueEntityId() {
         if (ENTITY_ID == null) {
             try {
-                final Field entityCount = Class.forName("net.minecraft.world.entity.Entity").getDeclaredField("c");
+                final Field entityCount = Class.forName("net.minecraft.world.entity.Entity").getDeclaredField("d");
                 entityCount.setAccessible(true);
                 ENTITY_ID = (AtomicInteger) entityCount.get(null);
             } catch (final ReflectiveOperationException e) {

--- a/src/main/java/me/mattstudios/holovid/compatability/wrappers/Wrapper1_20.java
+++ b/src/main/java/me/mattstudios/holovid/compatability/wrappers/Wrapper1_20.java
@@ -1,0 +1,4 @@
+package me.mattstudios.holovid.compatability.wrappers;
+
+public class Wrapper1_20 extends Wrapper1_19_4 {
+}

--- a/src/main/java/me/mattstudios/holovid/compatability/wrappers/Wrapper1_20_1.java
+++ b/src/main/java/me/mattstudios/holovid/compatability/wrappers/Wrapper1_20_1.java
@@ -1,0 +1,4 @@
+package me.mattstudios.holovid.compatability.wrappers;
+
+public class Wrapper1_20_1 extends Wrapper1_20 {
+}

--- a/src/main/java/me/mattstudios/holovid/download/VideoDownloader.java
+++ b/src/main/java/me/mattstudios/holovid/download/VideoDownloader.java
@@ -58,6 +58,8 @@ public abstract class VideoDownloader {
 
         plugin.resetCurrentDownloader();
 
+
+
         // Play the video!
         plugin.getVideoProcessor().play(player, videoFile, videoUrl, prepareAudio, plugin.getDisplayHeight(), plugin.getDisplayWidth(), frames, fps, interlace);
     }

--- a/src/main/java/me/mattstudios/holovid/download/YouTubeDownloader.java
+++ b/src/main/java/me/mattstudios/holovid/download/YouTubeDownloader.java
@@ -27,16 +27,14 @@ public final class YouTubeDownloader extends VideoDownloader {
     }
 
     public void download0(final Player player, final URL videoUrl, final boolean interlace) {
+        // Gets the video ID
+        String id;
+        if (videoUrl.getHost().equalsIgnoreCase("youtu.be")){
+            id = videoUrl.getPath().substring(1);
+        }else{
+            id = videoUrl.getQuery().substring(2);
+        }
         try {
-            // Gets the video ID
-            String id;
-            Bukkit.broadcastMessage(videoUrl.getHost());
-            if (videoUrl.getHost().equalsIgnoreCase("youtu.be")){
-                id = videoUrl.getPath().substring(1);
-            }else{
-                id = videoUrl.getQuery().substring(2);
-            }
-
             final RequestVideoInfo request = new RequestVideoInfo(id);
             final Response<VideoInfo> response = downloader.getVideoInfo(request);
             final VideoInfo videoInfo = response.data();

--- a/src/main/java/me/mattstudios/holovid/download/YouTubeDownloader.java
+++ b/src/main/java/me/mattstudios/holovid/download/YouTubeDownloader.java
@@ -49,7 +49,7 @@ public final class YouTubeDownloader extends VideoDownloader {
 
             // Gets the format to use on the download (this one has been the only one to work so far)
             final List<VideoWithAudioFormat> videoWithAudioFormats = videoInfo.videoWithAudioFormats();
-            //This is set to 1 because youtube's lowest quality uses some weird codec which Jcodec does not understand
+            //This is set to 1 because YouTube's lowest quality uses some weird codec which Jcodec does not understand
             final VideoWithAudioFormat format = videoWithAudioFormats.get(1);
 
             // Downloads the video into the videos dir
@@ -64,7 +64,7 @@ public final class YouTubeDownloader extends VideoDownloader {
 
             // Calculates how many frames the video has
             final List<VideoFormat> videoQuality = videoInfo.videoFormats();
-            final int fps = videoQuality.get(0).fps();
+            final int fps = videoQuality.get(1).fps();
             final int frames = fps * videoInfo.details().lengthSeconds();
             final boolean prepareAudio = frames / fps < Holovid.MAX_SECONDS_FOR_AUDIO;
             saveDataAndPlay(player, videoFile, videoUrl, outputDir, prepareAudio, frames, fps, interlace);

--- a/src/main/java/me/mattstudios/holovid/download/YouTubeDownloader.java
+++ b/src/main/java/me/mattstudios/holovid/download/YouTubeDownloader.java
@@ -8,6 +8,7 @@ import com.github.kiulian.downloader.model.videos.VideoInfo;
 import com.github.kiulian.downloader.model.videos.formats.VideoFormat;
 import com.github.kiulian.downloader.model.videos.formats.VideoWithAudioFormat;
 import me.mattstudios.holovid.Holovid;
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
 import java.io.File;
@@ -26,11 +27,18 @@ public final class YouTubeDownloader extends VideoDownloader {
     }
 
     public void download0(final Player player, final URL videoUrl, final boolean interlace) {
-        // Gets the video ID
-        final String id = videoUrl.getQuery().substring(2);
         try {
-            final RequestVideoInfo reqest = new RequestVideoInfo(id);
-            final Response<VideoInfo> response = downloader.getVideoInfo(reqest);
+            // Gets the video ID
+            String id;
+            Bukkit.broadcastMessage(videoUrl.getHost());
+            if (videoUrl.getHost().equalsIgnoreCase("youtu.be")){
+                id = videoUrl.getPath().substring(1);
+            }else{
+                id = videoUrl.getQuery().substring(2);
+            }
+
+            final RequestVideoInfo request = new RequestVideoInfo(id);
+            final Response<VideoInfo> response = downloader.getVideoInfo(request);
             final VideoInfo videoInfo = response.data();
 
             final File outputDir = getOutputDirForTitle(videoInfo.details().title());
@@ -49,7 +57,7 @@ public final class YouTubeDownloader extends VideoDownloader {
 
             // Gets the format to use on the download (this one has been the only one to work so far)
             final List<VideoWithAudioFormat> videoWithAudioFormats = videoInfo.videoWithAudioFormats();
-            //This is set to 1 because YouTube's lowest quality uses some weird codec which Jcodec does not understand
+            //This is set to 1 instead of 0 because YouTube's lowest quality uses some weird codec which Jcodec does not understand
             final VideoWithAudioFormat format = videoWithAudioFormats.get(1);
 
             // Downloads the video into the videos dir

--- a/src/main/java/me/mattstudios/holovid/download/YouTubeDownloader.java
+++ b/src/main/java/me/mattstudios/holovid/download/YouTubeDownloader.java
@@ -49,13 +49,15 @@ public final class YouTubeDownloader extends VideoDownloader {
 
             // Gets the format to use on the download (this one has been the only one to work so far)
             final List<VideoWithAudioFormat> videoWithAudioFormats = videoInfo.videoWithAudioFormats();
-            final VideoWithAudioFormat format = videoWithAudioFormats.get(0);
+            //This is set to 1 because youtube's lowest quality uses some weird codec which Jcodec does not understand
+            final VideoWithAudioFormat format = videoWithAudioFormats.get(1);
 
             // Downloads the video into the videos dir
             final RequestVideoFileDownload download = new RequestVideoFileDownload(format)
                     .saveTo(outputDir);
 
             final Response<File> downloadedVideo = downloader.downloadVideoFile(download);
+
 
             // Rename for easier access
             Files.move(downloadedVideo.data().toPath(), videoFile.toPath());

--- a/src/main/java/me/mattstudios/holovid/hologram/Hologram.java
+++ b/src/main/java/me/mattstudios/holovid/hologram/Hologram.java
@@ -192,11 +192,7 @@ public final class Hologram {
 
     void distributePacket(final Player player, final PacketContainer packetContainer) {
         if (!player.isOnline()) return;
-        try {
-            ProtocolLibrary.getProtocolManager().sendServerPacket(player, packetContainer);
-        } catch (final InvocationTargetException e) {
-            e.printStackTrace();
-        }
+        ProtocolLibrary.getProtocolManager().sendServerPacket(player, packetContainer);
     }
 
 }

--- a/src/main/java/me/mattstudios/holovid/hologram/Hologram.java
+++ b/src/main/java/me/mattstudios/holovid/hologram/Hologram.java
@@ -8,7 +8,6 @@ import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.Nullable;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.*;
 
 /**

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -2,4 +2,4 @@
 # You may go lower or higher (e.g. 256x144), but higher values will cause the client to have a harder time processing all of the incoming data.
 display-height: 72
 display-width: 128
-request-audio: true
+request-audio: false


### PR DESCRIPTION
This PR does the following:
- Add support for 1.19.x and 1.20.x
- Fixes an error on 1.18 and newer, because 1.18.1 extended 1.17 instead of 1.17.1
- Update dependencies to latest versions
- Disable audio loading by default, due to the api server not being up
- Updates to java 17, this will probably break 1.16 support by default, but they can use -DPaper.IgnoreJavaVersion=true
- Adds support for youtu.be links, closes #23 